### PR TITLE
fix: pragma restrictions

### DIFF
--- a/contracts/ConstAddressDeployer.sol
+++ b/contracts/ConstAddressDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 contract ConstAddressDeployer {
     error FailedInit();

--- a/contracts/StringAddressUtils.sol
+++ b/contracts/StringAddressUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 library StringToAddress {
     function toAddress(string memory _a) internal pure returns (address) {

--- a/contracts/StringBytesUtils.sol
+++ b/contracts/StringBytesUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 library StringToBytes32 {
     error InvalidStringLength();

--- a/contracts/executables/AxelarForecallable.sol
+++ b/contracts/executables/AxelarForecallable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { IAxelarGateway } from '../interfaces/IAxelarGateway.sol';
 import { IERC20 } from '../interfaces/IERC20.sol';

--- a/contracts/interfaces/IAxelarGateway.sol
+++ b/contracts/interfaces/IAxelarGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 interface IAxelarGateway {
     /**********\

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.

--- a/contracts/interfaces/IERC20MintableBurnable.sol
+++ b/contracts/interfaces/IERC20MintableBurnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20 } from './IERC20.sol';
 

--- a/contracts/interfaces/IERC721MintableBurnable.sol
+++ b/contracts/interfaces/IERC721MintableBurnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC721 } from './IERC721.sol';
 

--- a/contracts/interfaces/IUpgradable.sol
+++ b/contracts/interfaces/IUpgradable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 // General interface for upgradable contracts
 interface IUpgradable {

--- a/contracts/nft-linking/NftLinker.sol
+++ b/contracts/nft-linking/NftLinker.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { AxelarExecutable } from '../executables/AxelarExecutable.sol';
 import { StringToAddress } from '../StringAddressUtils.sol';

--- a/contracts/nft-linking/NftLinkerLockUnlock.sol
+++ b/contracts/nft-linking/NftLinkerLockUnlock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC721 } from '../interfaces/IERC721.sol';
 import { NftLinker } from './NftLinker.sol';

--- a/contracts/nft-linking/NftLinkerMintBurn.sol
+++ b/contracts/nft-linking/NftLinkerMintBurn.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC721MintableBurnable } from '../interfaces/IERC721MintableBurnable.sol';
 import { NftLinker } from './NftLinker.sol';

--- a/contracts/nft-linking/NftLinkerProxy.sol
+++ b/contracts/nft-linking/NftLinkerProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { Proxy } from '../upgradables/Proxy.sol';
 

--- a/contracts/test/UtilTest.sol
+++ b/contracts/test/UtilTest.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.9;
 
 import { StringToAddress, AddressToString } from '../StringAddressUtils.sol';
-import { Bytes32ToString, StringToBytes32 } from '../StringBytesUtil.sol';
+import { Bytes32ToString, StringToBytes32 } from '../StringBytesUtils.sol';
 
 contract UtilTest {
     using AddressToString for address;

--- a/contracts/token-linking/TokenLinker.sol
+++ b/contracts/token-linking/TokenLinker.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { AxelarExecutable } from '../executables/AxelarExecutable.sol';
 import { StringToAddress } from '../StringAddressUtils.sol';

--- a/contracts/token-linking/TokenLinkerLockUnlock.sol
+++ b/contracts/token-linking/TokenLinkerLockUnlock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20 } from '../interfaces/IERC20.sol';
 import { TokenLinker } from './TokenLinker.sol';

--- a/contracts/token-linking/TokenLinkerMintBurn.sol
+++ b/contracts/token-linking/TokenLinkerMintBurn.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20MintableBurnable } from '../interfaces/IERC20MintableBurnable.sol';
 import { TokenLinker } from './TokenLinker.sol';

--- a/contracts/token-linking/TokenLinkerNative.sol
+++ b/contracts/token-linking/TokenLinkerNative.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { TokenLinker } from './TokenLinker.sol';
 

--- a/contracts/token-linking/TokenLinkerProxy.sol
+++ b/contracts/token-linking/TokenLinkerProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { Proxy } from '../upgradables/Proxy.sol';
 

--- a/contracts/upgradables/Proxy.sol
+++ b/contracts/upgradables/Proxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import { IUpgradable } from '../interfaces/IUpgradable.sol';
 

--- a/contracts/upgradables/Upgradable.sol
+++ b/contracts/upgradables/Upgradable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
 import '../interfaces/IUpgradable.sol';
 


### PR DESCRIPTION
* [x] Making required pragma to be `^0.8.0` so SDK can be used with any solidity project