### PR TITLE
refactor: add caller address in role related events [AXE-2407]

### DIFF
--- a/contracts/interfaces/IRolesBase.sol
+++ b/contracts/interfaces/IRolesBase.sol
@@ -15,8 +15,8 @@ interface IRolesBase {
     error InvalidProposedRoles(address fromAccount, address toAccount, uint8[] roles);
 
     event RolesProposed(address indexed fromAccount, address indexed toAccount, uint8[] roles);
-    event RolesAdded(address indexed account, uint8[] roles);
-    event RolesRemoved(address indexed account, uint8[] roles);
+    event RolesAdded(address indexed caller, address indexed account, uint8[] roles);
+    event RolesRemoved(address indexed caller, address indexed account, uint8[] roles);
 
     /**
      * @notice Checks if an account has a role.

--- a/contracts/utils/RolesBase.sol
+++ b/contracts/utils/RolesBase.sol
@@ -168,7 +168,7 @@ contract RolesBase is IRolesBase {
 
         _setRoles(account, accountRoles);
 
-        emit RolesAdded(account, roles);
+        emit RolesAdded(msg.sender, account, roles);
     }
 
     /**
@@ -199,7 +199,7 @@ contract RolesBase is IRolesBase {
 
         _setRoles(account, accountRoles);
 
-        emit RolesRemoved(account, roles);
+        emit RolesRemoved(msg.sender, account, roles);
     }
 
     /**

--- a/test/utils/Roles.js
+++ b/test/utils/Roles.js
@@ -353,9 +353,9 @@ describe('Roles', () => {
 
       await expect(testRoles.transferRoles(userWallet.address, roles))
         .to.emit(testRoles, 'RolesRemoved')
-        .withArgs(ownerWallet.address, roles)
+        .withArgs(ownerWallet.address, ownerWallet.address, roles)
         .to.emit(testRoles, 'RolesAdded')
-        .withArgs(userWallet.address, roles);
+        .withArgs(ownerWallet.address, userWallet.address, roles);
 
       expect(await testRoles.getAccountRoles(userWallet.address)).to.equal(6); // 6 is the binary representation of roles [1, 2]
       expect(await testRoles.getAccountRoles(ownerWallet.address)).to.equal(8); // 8 is a binary representation of role 3, other roles transferred
@@ -397,13 +397,13 @@ describe('Roles', () => {
 
       await expect(testRoles.addRole(userWallet.address, role))
         .to.emit(testRoles, 'RolesAdded')
-        .withArgs(userWallet.address, [role]);
+        .withArgs(ownerWallet.address, userWallet.address, [role]);
 
       expect(await testRoles.getAccountRoles(userWallet.address)).to.equal(4); // 4 is the binary representation of roles [2]
 
       await expect(testRoles.removeRole(userWallet.address, role))
         .to.emit(testRoles, 'RolesRemoved')
-        .withArgs(userWallet.address, [role]);
+        .withArgs(ownerWallet.address, userWallet.address, [role]);
 
       expect(await testRoles.getAccountRoles(userWallet.address)).to.equal(0);
     });


### PR DESCRIPTION
Added caller address to be also emitted when a role is being assigned or removed for a account [AXE-2407](https://axelarnetwork.atlassian.net/browse/AXE-2407)

[AXE-2407]: https://axelarnetwork.atlassian.net/browse/AXE-2407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ