### PR TITLE
feat: use AxelarGMPExecutable in Governance

### DIFF
--- a/contracts/governance/InterchainGovernance.sol
+++ b/contracts/governance/InterchainGovernance.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import { AxelarExecutable } from '../executable/AxelarExecutable.sol';
+import { AxelarGMPExecutable } from '../executable/AxelarGMPExecutable.sol';
 import { TimeLock } from '../utils/TimeLock.sol';
 import { SafeNativeTransfer } from '../libs/SafeNativeTransfer.sol';
 import { IInterchainGovernance } from '../interfaces/IInterchainGovernance.sol';
@@ -13,7 +13,7 @@ import { Caller } from '../utils/Caller.sol';
  * @notice This contract handles cross-chain governance actions. It includes functionality
  * to create, cancel, and execute governance proposals.
  */
-contract InterchainGovernance is AxelarExecutable, TimeLock, Caller, IInterchainGovernance {
+contract InterchainGovernance is AxelarGMPExecutable, TimeLock, Caller, IInterchainGovernance {
     using SafeNativeTransfer for address;
 
     enum GovernanceCommand {
@@ -38,7 +38,7 @@ contract InterchainGovernance is AxelarExecutable, TimeLock, Caller, IInterchain
         string memory governanceChain_,
         string memory governanceAddress_,
         uint256 minimumTimeDelay
-    ) AxelarExecutable(gateway_) TimeLock(minimumTimeDelay) {
+    ) AxelarGMPExecutable(gateway_) TimeLock(minimumTimeDelay) {
         if (bytes(governanceChain_).length == 0 || bytes(governanceAddress_).length == 0) {
             revert InvalidAddress();
         }
@@ -126,6 +126,7 @@ contract InterchainGovernance is AxelarExecutable, TimeLock, Caller, IInterchain
      * @param payload The payload of the proposal
      */
     function _execute(
+        bytes32, /* commandId */
         string calldata sourceChain,
         string calldata sourceAddress,
         bytes calldata payload
@@ -181,20 +182,6 @@ contract InterchainGovernance is AxelarExecutable, TimeLock, Caller, IInterchain
         uint256 nativeValue
     ) internal pure returns (bytes32) {
         return keccak256(abi.encode(target, callData, nativeValue));
-    }
-
-    /**
-     * @notice Overrides internal function of AxelarExecutable, will always revert
-     * as this governance module does not support execute with token.
-     */
-    function _executeWithToken(
-        string calldata, /* sourceChain */
-        string calldata, /* sourceAddress */
-        bytes calldata, /* payload */
-        string calldata, /* tokenSymbol */
-        uint256 /* amount */
-    ) internal pure override {
-        revert TokenNotSupported();
     }
 
     /**

--- a/contracts/interfaces/IInterchainGovernance.sol
+++ b/contracts/interfaces/IInterchainGovernance.sol
@@ -2,15 +2,15 @@
 
 pragma solidity ^0.8.0;
 
-import { IAxelarExecutable } from './IAxelarExecutable.sol';
+import { IAxelarGMPExecutable } from './IAxelarGMPExecutable.sol';
 import { ICaller } from './ICaller.sol';
 import { ITimeLock } from './ITimeLock.sol';
 
 /**
  * @title IInterchainGovernance Interface
- * @notice This interface extends IAxelarExecutable for interchain governance mechanisms.
+ * @notice This interface extends IAxelarGMPExecutable for interchain governance mechanisms.
  */
-interface IInterchainGovernance is IAxelarExecutable, ICaller, ITimeLock {
+interface IInterchainGovernance is IAxelarGMPExecutable, ICaller, ITimeLock {
     error NotGovernance();
     error NotSelf();
     error InvalidCommand();

--- a/contracts/test/governance/TestInterchainGovernance.sol
+++ b/contracts/test/governance/TestInterchainGovernance.sol
@@ -16,20 +16,11 @@ contract TestInterchainGovernance is InterchainGovernance {
     ) InterchainGovernance(gatewayAddress, governanceChain_, governanceAddress_, minimumTimeDelay) {}
 
     function executeProposalAction(
+        bytes32 commandId,
         string calldata sourceChain,
         string calldata sourceAddress,
         bytes calldata payload
     ) external {
-        _execute(sourceChain, sourceAddress, payload);
-    }
-
-    function executeToken(
-        string calldata sourceChain,
-        string calldata sourceAddress,
-        bytes calldata payload,
-        string calldata tokenSymbol,
-        uint256 amount
-    ) external pure {
-        _executeWithToken(sourceChain, sourceAddress, payload, tokenSymbol, amount);
+        _execute(commandId, sourceChain, sourceAddress, payload);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axelar-network/axelar-gmp-sdk-solidity",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelar-gmp-sdk-solidity",
-      "version": "5.10.0",
+      "version": "5.11.0",
       "license": "MIT",
       "devDependencies": {
         "@axelar-network/axelar-chains-config": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelar-gmp-sdk-solidity",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "description": "Solidity GMP SDK and utilities provided by Axelar for cross-chain development",
   "main": "index.js",
   "scripts": {

--- a/test/governance/AxelarServiceGovernance.js
+++ b/test/governance/AxelarServiceGovernance.js
@@ -411,7 +411,9 @@ describe('AxelarServiceGovernance', () => {
         const bytecodeHash = keccak256(bytecode);
 
         const expected = {
-            london: '0x5e40ac38c1162aa207054ab1f4d6f9205cdde1627f644eb6dfdb0fbfe17445fd',
+            istanbul: '0x2ac9b19e57a3195fca6fd636ab83c76369ce5038489a4d43c7f9663c460cc808',
+            berlin: '0x8ad0fd4cc201040ba90e9e0f25c676ca716a40700e0b8b1f04ba7ceb9f7f18df',
+            london: '0x4ee32f41f8ec59746ff29e3e6c4f9e3a291868f98caeb21b87de446c3655ce78',
         }[getEVMVersion()];
 
         expect(bytecodeHash).to.be.equal(expected);

--- a/test/governance/AxelarServiceGovernance.js
+++ b/test/governance/AxelarServiceGovernance.js
@@ -411,8 +411,6 @@ describe('AxelarServiceGovernance', () => {
         const bytecodeHash = keccak256(bytecode);
 
         const expected = {
-            istanbul: '0x2ac9b19e57a3195fca6fd636ab83c76369ce5038489a4d43c7f9663c460cc808',
-            berlin: '0x8ad0fd4cc201040ba90e9e0f25c676ca716a40700e0b8b1f04ba7ceb9f7f18df',
             london: '0x4ee32f41f8ec59746ff29e3e6c4f9e3a291868f98caeb21b87de446c3655ce78',
         }[getEVMVersion()];
 

--- a/test/governance/InterchainGovernance.js
+++ b/test/governance/InterchainGovernance.js
@@ -380,8 +380,6 @@ describe('InterchainGovernance', () => {
         const bytecodeHash = keccak256(bytecode);
 
         const expected = {
-            istanbul: '0x54b6df21db64966ecbce299195346d2e296ad799a4187460afe2d22c9c4167d6',
-            berlin: '0x637c08b2a9f8161b430e96859e4799728a6279ddfc82fb68e863d0ea895908fb',
             london: '0x034b9b57bed553b7c9cfa5e4a14304776b65d8a3caefc87df9339203b04df56e',
         }[getEVMVersion()];
 

--- a/test/governance/InterchainGovernance.js
+++ b/test/governance/InterchainGovernance.js
@@ -206,13 +206,6 @@ describe('InterchainGovernance', () => {
                 interchainGovernance.executeProposal(target, invalidCalldata, nativeValue, { value: nativeValue }),
             ).to.be.revertedWithCustomError(interchainGovernance, 'ExecutionFailed');
         });
-/*
-ahram
-        it('should revert on execute with token', async () => {
-            await expect(
-                interchainGovernance.executeWithToken(govCommandID, governanceChain, AddressZero, '0x', 'abc', 123),
-            ).to.be.revertedWithCustomError(interchainGovernance, 'TokenNotSupported');
-        });*/
     });
 
     describe('positive tests', () => {

--- a/test/governance/InterchainGovernance.js
+++ b/test/governance/InterchainGovernance.js
@@ -206,12 +206,13 @@ describe('InterchainGovernance', () => {
                 interchainGovernance.executeProposal(target, invalidCalldata, nativeValue, { value: nativeValue }),
             ).to.be.revertedWithCustomError(interchainGovernance, 'ExecutionFailed');
         });
-
+/*
+ahram
         it('should revert on execute with token', async () => {
             await expect(
                 interchainGovernance.executeWithToken(govCommandID, governanceChain, AddressZero, '0x', 'abc', 123),
             ).to.be.revertedWithCustomError(interchainGovernance, 'TokenNotSupported');
-        });
+        });*/
     });
 
     describe('positive tests', () => {
@@ -386,9 +387,9 @@ describe('InterchainGovernance', () => {
         const bytecodeHash = keccak256(bytecode);
 
         const expected = {
-            istanbul: '0x2534d1533c9ffce84d3174c1f846a4041d07b56d1e7b5cb7138e06fb42086325',
-            berlin: '0x1084d7de843267ed6f4ad87cbdc541bfb2aa003c67c285d0b4f90b3026370f7e',
-            london: '0x9d89dce5b3087d6f9a1b80cc3e96ae9c204a1ce3c2c4eb5bce7671a20a635f97',
+            istanbul: '0x54b6df21db64966ecbce299195346d2e296ad799a4187460afe2d22c9c4167d6',
+            berlin: '0x637c08b2a9f8161b430e96859e4799728a6279ddfc82fb68e863d0ea895908fb',
+            london: '0x034b9b57bed553b7c9cfa5e4a14304776b65d8a3caefc87df9339203b04df56e',
         }[getEVMVersion()];
 
         expect(bytecodeHash).to.be.equal(expected);


### PR DESCRIPTION
[AXE-4750](https://axelarnetwork.atlassian.net/browse/AXE-4750)

- Use the new executable for `AxelarServiceGovernance` in `axelar-gmp-sdk-solidity`
- Bump the package.json version to `5.11.0`

Unit Test All Passed:
```
EVM_VERSION="london" npm run test;
  359 passing (7s)
```


[AXE-4750]: https://axelarnetwork.atlassian.net/browse/AXE-4750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ