### PR TITLE
chore: remove incorrect natspec

### DIFF
--- a/contracts/types/WeightedMultisigTypes.sol
+++ b/contracts/types/WeightedMultisigTypes.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.0;
  * @notice This struct represents the weighted signers payload
  * @param signers The list of signers
  * @param weights The list of weights
- * @param threshold The threshold for the signers
  */
 struct WeightedSigner {
     address signer;

--- a/contracts/types/WeightedMultisigTypes.sol
+++ b/contracts/types/WeightedMultisigTypes.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.0;
 
 /**
- * @notice This struct represents the weighted signers payload
- * @param signers The list of signers
- * @param weights The list of weights
+ * @notice This struct represents the weighted signer
+ * @param signer The address of the weighted signer
+ * @param weight The weight of the weighted singer
  */
 struct WeightedSigner {
     address signer;


### PR DESCRIPTION
[AXE-5208](https://axelarnetwork.atlassian.net/browse/AXE-5208)
- removed incorrect natspec in `WightedMultisigTypes.sol`

[AXE-5208]: https://axelarnetwork.atlassian.net/browse/AXE-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ