### PR TITLE
docs(gateway): correct callContract payload param

### DIFF
--- a/contracts/gateway/BaseAmplifierGateway.sol
+++ b/contracts/gateway/BaseAmplifierGateway.sol
@@ -34,7 +34,7 @@ abstract contract BaseAmplifierGateway is IBaseAmplifierGateway {
      * This function is the entry point for general message passing between chains.
      * @param destinationChain The chain where the destination contract exists. A registered chain name on Axelar must be used here
      * @param destinationContractAddress The address of the contract to call on the destination chain
-     * @param payload The payload to be sent to the destination contract, usually representing an encoded function call with arguments
+     * @param payload The payload to be sent to the destination contract
      */
     function callContract(
         string calldata destinationChain,


### PR DESCRIPTION
based on a comment in a PR for the `axelar-cgp-soroban` repo (https://github.com/axelarnetwork/axelar-cgp-soroban/pull/42#discussion_r1815635130), `payload` isn't just an encoded function call.