### PR TITLE
refactor: remove the deprecated sendToken

### DIFF
--- a/contracts/interfaces/IAxelarGatewayWithToken.sol
+++ b/contracts/interfaces/IAxelarGatewayWithToken.sol
@@ -11,23 +11,6 @@ import { IAxelarGateway } from './IAxelarGateway.sol';
  */
 interface IAxelarGatewayWithToken is IAxelarGateway {
     /**
-     * @notice Emitted when a token is sent to another chain.
-     * @dev Logs the attempt to send tokens to a recipient on another chain.
-     * @param sender The address of the sender who initiated the token transfer.
-     * @param destinationChain The name of the destination chain.
-     * @param destinationAddress The address of the recipient on the destination chain.
-     * @param symbol The symbol of the token being transferred.
-     * @param amount The amount of the tokens being transferred.
-     */
-    event TokenSent(
-        address indexed sender,
-        string destinationChain,
-        string destinationAddress,
-        string symbol,
-        uint256 amount
-    );
-
-    /**
      * @notice Emitted when a contract call is made through the gateway along with a token transfer.
      * @dev Logs the attempt to call a contract on another chain with an associated token transfer.
      * @param sender The address of the sender who initiated the contract call with token.
@@ -72,21 +55,6 @@ interface IAxelarGatewayWithToken is IAxelarGateway {
         bytes32 sourceTxHash,
         uint256 sourceEventIndex
     );
-
-    /**
-     * @notice Sends tokens to another chain.
-     * @dev Initiates a cross-chain token transfer through the gateway to the specified destination chain and recipient.
-     * @param destinationChain The name of the destination chain.
-     * @param destinationAddress The address of the recipient on the destination chain.
-     * @param symbol The symbol of the token being transferred.
-     * @param amount The amount of the tokens being transferred.
-     */
-    function sendToken(
-        string calldata destinationChain,
-        string calldata destinationAddress,
-        string calldata symbol,
-        uint256 amount
-    ) external;
 
     /**
      * @notice Makes a contract call on another chain with an associated token transfer.

--- a/contracts/test/gmp/DestinationChainSwapExecutable.sol
+++ b/contracts/test/gmp/DestinationChainSwapExecutable.sol
@@ -16,21 +16,35 @@ contract DestinationChainSwapExecutable is AxelarExecutableWithToken {
     function _executeWithToken(
         bytes32, /*commandId*/
         string calldata sourceChain,
-        string calldata, /*sourceAddress*/
+        string calldata sourceAddress,
         bytes calldata payload,
         string calldata tokenSymbolA,
         uint256 amount
     ) internal override {
         (string memory tokenSymbolB, string memory recipient) = abi.decode(payload, (string, string));
 
-        address tokenA = gatewayWithToken().tokenAddresses(tokenSymbolA);
-        address tokenB = gatewayWithToken().tokenAddresses(tokenSymbolB);
+        // swap
+        uint256 convertedAmount;
+        address tokenB;
+        {
+            address tokenA = gatewayWithToken().tokenAddresses(tokenSymbolA);
+            tokenB = gatewayWithToken().tokenAddresses(tokenSymbolB);
+            IERC20(tokenA).approve(address(swapper), amount);
+            convertedAmount = swapper.swap(tokenA, tokenB, amount, address(this));
+        }
 
-        IERC20(tokenA).approve(address(swapper), amount);
-        uint256 convertedAmount = swapper.swap(tokenA, tokenB, amount, address(this));
-
-        IERC20(tokenB).approve(address(gateway()), convertedAmount);
-        gatewayWithToken().sendToken(sourceChain, recipient, tokenSymbolB, convertedAmount);
+        // send back
+        {
+            bytes memory returnPayload = abi.encode(recipient);
+            IERC20(tokenB).approve(address(gatewayWithToken()), convertedAmount);
+            gatewayWithToken().callContractWithToken(
+                sourceChain,
+                sourceAddress,
+                returnPayload,
+                tokenSymbolB,
+                convertedAmount
+            );
+        }
     }
 
     function _execute(

--- a/contracts/test/gmp/DestinationChainSwapExpress.sol
+++ b/contracts/test/gmp/DestinationChainSwapExpress.sol
@@ -42,14 +42,29 @@ contract DestinationChainSwapExpress is AxelarExpressExecutableWithToken {
     ) internal override {
         (string memory tokenSymbolB, string memory recipient) = abi.decode(payload, (string, string));
 
-        address tokenA = gatewayWithToken().tokenAddresses(tokenSymbolA);
-        address tokenB = gatewayWithToken().tokenAddresses(tokenSymbolB);
+        // swap
+        uint256 convertedAmount;
+        address tokenB;
+        {
+            address tokenA = gatewayWithToken().tokenAddresses(tokenSymbolA);
+            tokenB = gatewayWithToken().tokenAddresses(tokenSymbolB);
+            IERC20(tokenA).approve(address(swapper), amount);
+            convertedAmount = swapper.swap(tokenA, tokenB, amount, address(this));
+        }
 
-        IERC20(tokenA).approve(address(swapper), amount);
-        uint256 convertedAmount = swapper.swap(tokenA, tokenB, amount, address(this));
+        // send back
+        {
+            bytes memory returnPayload = abi.encode(recipient);
+            IERC20(tokenB).approve(address(gatewayWithToken()), convertedAmount);
+            gatewayWithToken().callContractWithToken(
+                sourceChain,
+                sourceAddress,
+                returnPayload,
+                tokenSymbolB,
+                convertedAmount
+            );
+        }
 
-        IERC20(tokenB).approve(address(gatewayWithToken()), convertedAmount);
-        gatewayWithToken().sendToken(sourceChain, recipient, tokenSymbolB, convertedAmount);
         emit ExecutedWithToken(commandId, sourceChain, sourceAddress, payload, tokenSymbolA, amount);
     }
 

--- a/contracts/test/gmp/DestinationChainSwapExpressDisabled.sol
+++ b/contracts/test/gmp/DestinationChainSwapExpressDisabled.sol
@@ -27,21 +27,35 @@ contract DestinationChainSwapExpressDisabled is AxelarExecutableWithToken {
     function _executeWithToken(
         bytes32, /*commandId*/
         string calldata sourceChain,
-        string calldata, /*sourceAddress*/
+        string calldata sourceAddress,
         bytes calldata payload,
         string calldata tokenSymbolA,
         uint256 amount
     ) internal override {
         (string memory tokenSymbolB, string memory recipient) = abi.decode(payload, (string, string));
 
-        address tokenA = gatewayWithToken().tokenAddresses(tokenSymbolA);
-        address tokenB = gatewayWithToken().tokenAddresses(tokenSymbolB);
+        // swap
+        uint256 convertedAmount;
+        address tokenB;
+        {
+            address tokenA = gatewayWithToken().tokenAddresses(tokenSymbolA);
+            tokenB = gatewayWithToken().tokenAddresses(tokenSymbolB);
+            IERC20(tokenA).approve(address(swapper), amount);
+            convertedAmount = swapper.swap(tokenA, tokenB, amount, address(this));
+        }
 
-        IERC20(tokenA).approve(address(swapper), amount);
-        uint256 convertedAmount = swapper.swap(tokenA, tokenB, amount, address(this));
-
-        IERC20(tokenB).approve(address(gateway()), convertedAmount);
-        gatewayWithToken().sendToken(sourceChain, recipient, tokenSymbolB, convertedAmount);
+        // send back
+        {
+            bytes memory returnPayload = abi.encode(recipient);
+            IERC20(tokenB).approve(address(gatewayWithToken()), convertedAmount);
+            gatewayWithToken().callContractWithToken(
+                sourceChain,
+                sourceAddress,
+                returnPayload,
+                tokenSymbolB,
+                convertedAmount
+            );
+        }
     }
 
     function contractId() external pure returns (bytes32) {

--- a/contracts/test/gmp/SourceChainSwapCaller.sol
+++ b/contracts/test/gmp/SourceChainSwapCaller.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.0;
 
-import { IAxelarGatewayWithToken } from '../../interfaces/IAxelarGatewayWithToken.sol';
+import { AxelarExecutableWithToken } from '../../executable/AxelarExecutableWithToken.sol';
 import { IERC20 } from '../../interfaces/IERC20.sol';
+import { StringToAddress } from '../../libs/AddressString.sol';
 
-contract SourceChainSwapCaller {
-    IAxelarGatewayWithToken public gateway;
+contract SourceChainSwapCaller is AxelarExecutableWithToken {
     string public destinationChain;
     string public executableAddress;
 
@@ -14,8 +14,7 @@ contract SourceChainSwapCaller {
         address gateway_,
         string memory destinationChain_,
         string memory executableAddress_
-    ) {
-        gateway = IAxelarGatewayWithToken(gateway_);
+    ) AxelarExecutableWithToken(gateway_) {
         destinationChain = destinationChain_;
         executableAddress = executableAddress_;
     }
@@ -26,12 +25,34 @@ contract SourceChainSwapCaller {
         uint256 amount,
         string memory recipient
     ) external payable {
-        address tokenX = gateway.tokenAddresses(symbolA);
+        address tokenX = gatewayWithToken().tokenAddresses(symbolA);
         bytes memory payload = abi.encode(symbolB, recipient);
 
         IERC20(tokenX).transferFrom(msg.sender, address(this), amount);
 
-        IERC20(tokenX).approve(address(gateway), amount);
-        gateway.callContractWithToken(destinationChain, executableAddress, payload, symbolA, amount);
+        IERC20(tokenX).approve(address(gateway()), amount);
+        gatewayWithToken().callContractWithToken(destinationChain, executableAddress, payload, symbolA, amount);
+    }
+
+    function _executeWithToken(
+        bytes32, /*commandId*/
+        string calldata, /*sourceChain*/
+        string calldata, /*sourceAddress*/
+        bytes calldata payload,
+        string calldata tokenSymbolB,
+        uint256 amount
+    ) internal override {
+        string memory recipientStr = abi.decode(payload, (string));
+        address tokenB = gatewayWithToken().tokenAddresses(tokenSymbolB);
+        IERC20(tokenB).transfer(StringToAddress.toAddress(recipientStr), amount);
+    }
+
+    function _execute(
+        bytes32, /*commandId*/
+        string calldata, /*sourceChain*/
+        string calldata, /*sourceAddress*/
+        bytes calldata /*payload*/
+    ) internal pure override {
+        revert('Not implemented');
     }
 }

--- a/contracts/test/mocks/MockGateway.sol
+++ b/contracts/test/mocks/MockGateway.sol
@@ -41,16 +41,6 @@ contract MockGateway is IAxelarGatewayWithToken {
     |* Public Methods *|
     \******************/
 
-    function sendToken(
-        string calldata destinationChain,
-        string calldata destinationAddress,
-        string calldata symbol,
-        uint256 amount
-    ) external {
-        _burnTokenFrom(msg.sender, symbol, amount);
-        emit TokenSent(msg.sender, destinationChain, destinationAddress, symbol, amount);
-    }
-
     function callContract(
         string calldata destinationChain,
         string calldata destinationContractAddress,

--- a/test/GMP/GMP.js
+++ b/test/GMP/GMP.js
@@ -239,6 +239,9 @@ describe('GMP', () => {
                     symbolA,
                     swapAmount,
                 );
+                const returnPayload = defaultAbiCoder.encode(['string'], [userWallet.address.toString()]);
+                const returnPayloadHash = keccak256(returnPayload);
+
                 await expect(swap)
                     .to.emit(tokenA, 'Transfer')
                     .withArgs(destinationChainGateway.address, destinationChainSwapExecutable.address, swapAmount)
@@ -250,11 +253,13 @@ describe('GMP', () => {
                     )
                     .and.to.emit(tokenB, 'Transfer')
                     .withArgs(destinationChainSwapExecutable.address, destinationChainGateway.address, convertedAmount)
-                    .and.to.emit(destinationChainGateway, 'TokenSent')
+                    .and.to.emit(destinationChainGateway, 'ContractCallWithToken')
                     .withArgs(
                         destinationChainSwapExecutable.address,
                         sourceChain,
-                        userWallet.address.toString(),
+                        sourceChainSwapCaller.address.toString(),
+                        returnPayloadHash,
+                        returnPayload,
                         symbolB,
                         convertedAmount,
                     );

--- a/test/GMP/GMPE.js
+++ b/test/GMP/GMPE.js
@@ -201,11 +201,13 @@ describe('GMPE', async () => {
                 .withArgs(destinationChainTokenSwapper.address, destinationChainSwapExpress.address, convertedAmount)
                 .and.to.emit(tokenB, 'Transfer')
                 .withArgs(destinationChainSwapExpress.address, destinationChainGateway.address, convertedAmount)
-                .and.to.emit(destinationChainGateway, 'TokenSent')
+                .and.to.emit(destinationChainGateway, 'ContractCallWithToken')
                 .withArgs(
                     destinationChainSwapExpress.address,
                     sourceChain,
-                    userWallet.address.toString(),
+                    sourceChainSwapCaller.address.toString(),
+                    keccak256(defaultAbiCoder.encode(['string'], [userWallet.address.toString()])),
+                    defaultAbiCoder.encode(['string'], [userWallet.address.toString()]),
                     symbolB,
                     convertedAmount,
                 );


### PR DESCRIPTION
 The `sendToken` function and `TokenSent` event on `IAxelarGatewayWithToken` are deprecated in favour of `callContractWithToken`.

This PR removes `sendToken` from the interface and all test/mock contracts, and updates the cross-chain swap example flow to use `callContractWithToken` end-to-end.

Part of CPI-116

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the cross-chain swap return path and removes a gateway interface method/event, which can break downstream implementations and test expectations if any callers still rely on `sendToken`. Changes are largely isolated to interfaces, mocks, and example/test GMP contracts.
> 
> **Overview**
> Removes the deprecated `sendToken` function and `TokenSent` event from `IAxelarGatewayWithToken` and deletes the corresponding mock implementation in `MockGateway`.
> 
> Refactors the GMP swap example to return swapped tokens via `callContractWithToken` back to the source contract (propagating `sourceAddress`, encoding a return payload, and handling the callback in `SourceChainSwapCaller`), and updates JS tests to assert `ContractCallWithToken` events/payload hashes instead of `TokenSent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 075bcd4c0ead669def195965fef6c4d75b079ce2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->