### PR TITLE
ci: use GitHub App token in release workflows

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -70,6 +70,13 @@ jobs:
           echo "new_package_version=${NEW_PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "old_package_version=${OLD_PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       # Keep the version of the PRs up-to-date
       - name: Create Release Pull Request
         id: release-pr
@@ -80,7 +87,7 @@ jobs:
           title: 'chore(release): bump version from `${{ steps.extract-package-versions.outputs.old_package_version }}` to `${{ steps.extract-package-versions.outputs.new_package_version }}`'
           commit: 'chore(release): bump version from `${{ steps.extract-package-versions.outputs.old_package_version }}` to `${{ steps.extract-package-versions.outputs.new_package_version }}`'
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       # Refresh package-lock.json on the release branch so its version stays in sync.
       - name: Checkout release branch
@@ -95,7 +102,7 @@ jobs:
         if: steps.release-pr.outputs.hasChangesets == 'true'
         working-directory: release-branch
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           BASE_BRANCH: ${{ steps.branch-check.outputs.branch_name }}
         run: |
           npm install --package-lock-only
@@ -107,5 +114,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package-lock.json
           git commit -m "chore(release): sync package-lock.json"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin "HEAD:changeset-release/${BASE_BRANCH}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,13 @@ jobs:
         with:
           install-nodejs: 'true'
 
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       # Publishes a release in case the release isn't published
       - name: Publish release
         id: publish-release
@@ -38,7 +45,7 @@ jobs:
           publish: npm run release
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Replace PAT_TOKEN with a short-lived token generated via the actions/create-github-app-token action. Applies to create-release-pr and release workflows. Same pattern as axelarnetwork/axelar-amplifier-stellar#372.