### PR TITLE
ci: pin actions/create-github-app-token to commit SHA

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -71,7 +71,7 @@ jobs:
           echo "old_package_version=${OLD_PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.BOT_APP_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           install-nodejs: 'true'
 
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.BOT_APP_ID }}


### PR DESCRIPTION
Pin the GitHub App token action to a commit SHA (v3.2.0) instead of the mutable v3 tag, matching the pinning convention used by the other actions in these workflows. The action receives the App's private key as input, so a tag-level supply chain attack would be high-impact.

Part of CPI-302